### PR TITLE
Fix: Remove lang in script tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Elements Changelog
 
+## 0.2.2 ([#12](https://github.com/ignatiusmb/elements/pull/12))
+
+- Remove lang in script tags
+
 ## 0.2.1 ([#11](https://github.com/ignatiusmb/elements/pull/11))
 
 - Include individual files from root folder in published package

--- a/essentials/Image.svelte
+++ b/essentials/Image.svelte
@@ -1,5 +1,6 @@
-<script lang="ts">
-	export let src: string, alt: string;
+<script>
+	export let src = '';
+	export let alt = '';
 	export let overlay = false;
 	export let absolute = false;
 	export let ratio = 9 / 16;

--- a/functional/Pagination.svelte
+++ b/functional/Pagination.svelte
@@ -1,10 +1,10 @@
-<script lang="ts">
-	import type { Writable } from 'svelte/store';
-	export let store: Writable<number>;
-	export let total: number;
-	export let bound: number;
+<script>
+	import { writable } from 'svelte/store';
+	export let store = writable(0);
+	export let total = 0;
+	export let bound = 1;
 	import Icon from '../essentials/Icon.svelte';
-	function setPage(index: number) {
+	function setPage(index) {
 		if (index < 0) return;
 		index = Math.round(index);
 		if (index > $store && curr + bound > total) return;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@ignatiusmb/elements",
   "author": "Ignatius Bagus",
   "description": "Reusable and functional web components",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
Fix to allow users to use without needing to have svelte preprocessor