### PR TITLE
Fix: Remove global modifier

### DIFF
--- a/src/ButtonLink.svelte
+++ b/src/ButtonLink.svelte
@@ -23,7 +23,7 @@
 		text-transform: uppercase;
 		color: rgba(0, 0, 0, 0);
 	}
-	span :global(a) {
+	span > :global(a) {
 		user-select: none;
 		width: 100%;
 		padding: 0.5em 1em;
@@ -35,8 +35,8 @@
 	span:active {
 		color: rgba(var(--theme-secondary), 1);
 	}
-	span:hover :global(a),
-	span:active :global(a) {
+	span:hover > :global(a),
+	span:active > :global(a) {
 		text-shadow: 0 2ch 0 rgba(0, 0, 0, 0);
 		transform: translateY(0);
 	}

--- a/src/SearchBar.svelte
+++ b/src/SearchBar.svelte
@@ -96,20 +96,20 @@
 		background-color: rgb(var(--bg-color));
 	}
 	aside section label,
-	aside :global(section label) {
+	aside > :global(section label) {
 		cursor: pointer;
 		padding: 0.5em 0.25em;
 	}
 	aside section label span,
-	aside :global(section label span) {
+	aside > :global(section label span) {
 		color: rgb(var(--fg-secondary-color));
 	}
 	aside section input:checked + span,
-	aside :global(section input:checked + span) {
+	aside > :global(section input:checked + span) {
 		color: rgb(var(--fg-color));
 	}
 	aside section input:checked + span::after,
-	aside :global(section input:checked + span::after) {
+	aside > :global(section input:checked + span::after) {
 		content: '✔';
 		margin-left: 0.5em;
 	}

--- a/src/ThemeSwitcher.svelte
+++ b/src/ThemeSwitcher.svelte
@@ -45,12 +45,12 @@
 		cursor: pointer;
 		height: 1.5em;
 	}
-	span :global(svg) {
-		height: 100%;
-	}
-	span :global(path) {
+	span path {
 		fill: rgb(var(--fg-color));
 		transition: var(--t-duration, 300ms);
+	}
+	span > :global(svg) {
+		height: 100%;
 	}
 	.nice {
 		outline: none;


### PR DESCRIPTION
Remove global modifier from path in `ThemeSwitcher` to keep it scoped to built-in icons