### PR TITLE
Refactor: Change icons to feather

### DIFF
--- a/src/icons/build.js
+++ b/src/icons/build.js
@@ -6,7 +6,7 @@ const generate = (icon) => `<script>
 	export let size = 24;
 	export let weight = 1.5;
 	export let color = 'currentColor';
-  let className = "";
+  let className = '';
   export { className as class };
 </script>
 
@@ -30,10 +30,27 @@ const icons = Object.keys(feather).map((name) => {
 	return { original: name, pascal: name.replace(/\w+/g, pascalCase).replace(/-/g, '') };
 });
 
-const components = [];
-for (const { original, pascal } of icons) {
-	fs.writeFileSync(`./src/icons/${pascal}.svelte`, generate(original));
-	components.push(`export { default as ${pascal} } from './${pascal}.svelte';`);
+const exportComponents = (isDeclaration) => {
+	const imports = `import { SvelteComponent } from 'svelte';
+
+class Icon extends SvelteComponent {
+	size?: number;
+	weight?: number;
+	color?: string;
+	class?: string;
 }
-fs.writeFileSync('./src/icons/index.js', components.join('\n'));
-fs.writeFileSync('./src/icons/index.d.ts', components.join('\n'));
+`;
+
+	const components = isDeclaration ? [imports] : [];
+	for (const { original, pascal } of icons) {
+		if (isDeclaration) components.push(`export class ${pascal} extends Icon {}`);
+		else {
+			fs.writeFileSync(`./src/icons/${pascal}.svelte`, generate(original));
+			components.push(`export { default as ${pascal} } from './${pascal}.svelte';`);
+		}
+	}
+	return components.join('\n');
+};
+
+fs.writeFileSync('./src/icons/index.js', exportComponents());
+fs.writeFileSync('./src/icons/index.d.ts', exportComponents(true));

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,4 @@
-export * as Icons from './icons';
+export * as Feather from './icons';
 export * as Loader from './loader';
 
 // essentials

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-export * as Icons from './icons';
+export * as Feather from './icons';
 export * as Loader from './loader';
 
 // essentials


### PR DESCRIPTION
- Change `Icons` namespace to `Feather`
- Export generic class to not overload language server with whole components