### PR TITLE
Feat: Optimize Loader declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Elements Changelog
 
+## 0.5.0
+
+- Change `Icons` namespace to `Feather` and optimize `.d.ts` ([#19](https://github.com/ignatiusmb/elements/pull/19))
+- Change global styling to target child rather than descendant ([#18](https://github.com/ignatiusmb/elements/pull/18))
+- Optimize `Loader`'s `.d.ts` file ([#20](https://github.com/ignatiusmb/elements/pull/20))
+
 ## 0.4.2
 
 - Hotfix: Fix chevron icons misplacement in `Pagination`

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@ignatiusmb/elements",
   "author": "Ignatius Bagus",
   "description": "Reusable and functional web components",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "svelte": "src/index.js",

--- a/src/loader/index.d.ts
+++ b/src/loader/index.d.ts
@@ -1,1 +1,3 @@
-export { default as ThreeWavyBalls } from './ThreeWavyBalls.svelte';
+import type { SvelteComponent } from 'svelte';
+
+export class ThreeWavyBalls extends SvelteComponent {}


### PR DESCRIPTION
Change `Loader`'s `.d.ts` file to export generic class rather than the actual file