### PR TITLE
Fix: Remove spacing when no filter is passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Elements Changelog
 
+## Unreleased
+
+- Fix `SearchBar` spacing when filter is not used ([#21](https://github.com/ignatiusmb/elements/pull/21))
+
 ## 0.5.0
 
 - Change `Icons` namespace to `Feather` and optimize `.d.ts` ([#19](https://github.com/ignatiusmb/elements/pull/19))

--- a/src/SearchBar.svelte
+++ b/src/SearchBar.svelte
@@ -3,8 +3,8 @@
 	export let filters = null;
 	export let unique = null;
 	import { slide } from 'svelte/transition';
-	import { duration } from './options';
 	import { Filter } from './icons';
+	import { duration } from './options';
 	let show = false;
 </script>
 

--- a/src/SearchBar.svelte
+++ b/src/SearchBar.svelte
@@ -9,7 +9,7 @@
 </script>
 
 <div class="lmns lmns-search-bar">
-	<header>
+	<header class:filters>
 		<input type="text" bind:value={query} placeholder="Type in your search query here" />
 		{#if filters}
 			<span on:click={() => (show = !show)}>
@@ -47,6 +47,9 @@
 	header {
 		display: grid;
 		gap: 0.5em;
+		grid-template-columns: 1fr;
+	}
+	header.filters {
 		grid-template-columns: 1fr auto;
 	}
 	header input {


### PR DESCRIPTION
Fix spacing on `SearchBar` when filter is not used