### PR TITLE
Feat: Update Pagination element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 - Update `Pagination` element ([#26](https://github.com/ignatiusmb/elements/pull/26))
   - Add new exported prop `increment` to specify items per update
   - Fix `limit` going negative value and right Chevrons disabled class gets removed
-  - Fix `curr` value not adjusted when `total` is 0
+  - Fix `total` value 0 but `curr` is still incremented by one
+  - Fix `total` value changed but `$store` isn't readjusted
 - Export existing props from `Image` to `LazyLoadImage` ([#26](https://github.com/ignatiusmb/elements/pull/26))
 - Change CSS vars and fallbacks for `ButtonLink` and `SearchBar` ([#25](https://github.com/ignatiusmb/elements/pull/25))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Update `Pagination` element ([#26](https://github.com/ignatiusmb/elements/pull/26))
+- Update `Pagination` element ([#27](https://github.com/ignatiusmb/elements/pull/27))
   - Add new exported prop `increment` to specify items per update
   - Fix `limit` going negative value and right Chevrons disabled class gets removed
   - Fix `total` value 0 but `curr` is still incremented by one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Update `Pagination` element ([#27](https://github.com/ignatiusmb/elements/pull/27))
   - Add new exported prop `increment` to specify items per update
+  - Add new exported prop `tween` to iterate over items instead of jumping to it
   - Fix `limit` going negative value and right Chevrons disabled class gets removed
   - Fix `total` value 0 but `curr` is still incremented by one
   - Fix `total` value changed but `$store` isn't readjusted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Update `Pagination` element ([#26](https://github.com/ignatiusmb/elements/pull/26))
+  - Add new exported prop `increment` to specify items per update
+  - Fix `limit` going negative value and right Chevrons disabled class gets removed
+  - Fix `curr` value not adjusted when `total` is 0
 - Export existing props from `Image` to `LazyLoadImage` ([#26](https://github.com/ignatiusmb/elements/pull/26))
 - Change CSS vars and fallbacks for `ButtonLink` and `SearchBar` ([#25](https://github.com/ignatiusmb/elements/pull/25))
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Elements ![Total npm downloads](https://img.shields.io/npm/dt/@ignatiusmb/elements) &middot; ![Published npm version](https://img.shields.io/npm/v/@ignatiusmb/elements) ![Monthly npm downloads](https://img.shields.io/npm/dm/@ignatiusmb/elements) ![License](https://img.shields.io/github/license/ignatiusmb/elements) [![Made with Svelte](https://img.shields.io/badge/made%20with-Svelte-ff3e00)](https://svelte.dev/)
 
-> A collection of hassle-free and ready-to-use components made with Svelte. [Feather](https://feathericons.com/) icons included.
+> A collection of hassle-free and ready-to-use functional components made with Svelte. [Feather](https://feathericons.com/) icons included.
 
-Elements is a Svelte component library consisting of various essential, functional, and pre-styled components. Created with DRY principle in mind as well as utilizing Svelte being a compiler, components like `Link`, `Image`, `Dialog` or `Modal` can be created once in here and used in any project without having to copy the `.svelte` file or rewrite them in each repository.
+Elements is a Svelte component library consisting of various essential, functional, and pre-styled components. Created with DRY principle in mind as well as utilizing Svelte being a compiler.
+
+Elements is not a(nother) UI library / components library adhering to specific design language or certain guidelines. Though Elements has some generic components, the focus is mostly on its functionality. There's already a ton of UI libraries with various buttons, cards, menus, and other components in one complete package if you're looking for that kind of stuff.
 
 Originally made with ease of use in mind for personal projects only, turned into something potentially bigger and useful to other projects as well. As it grew bigger and more components being added, I realize this might also be beneficial to others as well, in hopes that this would help fellow Svelte developers in quickstarting new projects as well.
 
@@ -48,7 +50,9 @@ Import only the components you need, play around in the [REPL](https://svelte.de
 
 Please keep in mind that this is basically still a hobby project I'm doing to help myself in other projects. Elements will try to be as design agnostic as possible except for styled components, which would be whatever I thought was good at the time of making it. Elements does not adhere to any existing design language, any resemblance to certain design language is either inspired by or just purely coincidental. In other words, please do not expect a lot design-wise.
 
-I like to create my own components as pure as possible, meaning I would try my best to create it in pure HTML, vanilla JS, or in this case Svelte-flavored, before using third-party libraries. In which case, it wouldn't be a component here. Also, working with Sapper and already having a ton of devDependencies, installing more `svelte-*` packages e.g. `svelte-search-bar`, `svelte-pagination`, `svelte-theme-switcher`, and so on would make it harder to manage and quite the chore to keep up with each updates. Hence, why I try to (re)create the components and bundle it as one collection here.
+I personally never used a CSS framework or library and will not try to make one either, especially with Svelte where there's only a workaround, or escape hatch as they call it, using the `:global()` modifier. Either way, isn't it more fun to style your own website rather than using a pre-made UI component library? It would also make your website unique and better.
+
+Working with Sapper and already having a ton of devDependencies, installing `svelte-*` packages e.g. `svelte-search-bar`, `svelte-pagination`, `svelte-theme-switcher`, and so on feels like it would make it harder to manage and quite the chore to keep up with each updates. I also like to create my own components as pure as possible, and I find myself reusing the same components across multiple projects. Hence, why I try to (re)create most components myself and bundle it as one collection here in Elements, Svelte-flavoured.
 
 If some components you think are essential is missing and you feel it should be here, please understand that it was specifically excluded to spite you personally. All jokes aside, contributions are welcome as always!
 

--- a/README.md
+++ b/README.md
@@ -116,8 +116,6 @@ There's currently only one loader available to use, which is `ThreeWavyBalls`. M
 
 Dialog element backdrop can be clicked by the user to close the interface, its almost exactly the same as [`Modal`](#modal) with some minor difference in functionality, see [this question on Quora](https://www.quora.com/Whats-the-difference-between-a-modal-and-dialog) for more details on why.
 
-- `show` -
-
 ```svelte
 <script>
   import { Dialog } from '@ignatiusmb/elements';
@@ -161,8 +159,8 @@ Image element is created to have a fixed ratio, **not size**. It will be respons
 ```svelte
 <script>
   import { Image } from '@ignatiusmb/elements';
-  const src = "//example.com/image.png";
-  const alt = "An example text for this element";
+  const src = '//example.com/image.png';
+  const alt = 'An example text for this element';
 </script>
 
 <Image {src} {alt} contain />
@@ -173,8 +171,8 @@ Image element is created to have a fixed ratio, **not size**. It will be respons
 ```svelte
 <script>
   import { Image } from '@ignatiusmb/elements';
-  const src = "//example.com/image.png";
-  const alt = "An example text for this element";
+  const src = '//example.com/image.png';
+  const alt = 'An example text for this element';
 </script>
 
 <Image {src} {alt} overlay>
@@ -187,8 +185,8 @@ Image element is created to have a fixed ratio, **not size**. It will be respons
 ```svelte
 <script>
   import { Image } from '@ignatiusmb/elements';
-  const src = "//example.com/image.png";
-  const alt = "An example text for this element";
+  const src = '//example.com/image.png';
+  const alt = 'An example text for this element';
 </script>
 
 <div style="position: relative">
@@ -202,8 +200,8 @@ Image element is created to have a fixed ratio, **not size**. It will be respons
 ```svelte
 <script>
   import { Image } from '@ignatiusmb/elements';
-  const src = "//example.com/image.png";
-  const alt = "An example text for this element";
+  const src = '//example.com/image.png';
+  const alt = 'An example text for this element';
 </script>
 
 <!-- Square Image -->

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > A collection of hassle-free and ready-to-use functional components made with Svelte. [Feather](https://feathericons.com/) icons included.
 
-Elements is a Svelte component library consisting of various essential, functional, and pre-styled components. Created with DRY principle in mind as well as utilizing Svelte being a compiler.
+Elements is a Svelte component library consisting of various essential, mostly functional, and some pre-styled components. Create your own or use pre-existing, uniquely styled components and still get all the benefits from Elements. By utilizing [Svelte `<slot>`](https://svelte.dev/docs#slot), we're able to integrate our components while still getting the benefits of scoped styles and not having to worry about global styling modifiers or how to integrate components.
 
 Elements is not a(nother) UI library / components library adhering to specific design language or certain guidelines. Though Elements has some generic components, the focus is mostly on its functionality. There's already a ton of UI libraries with various buttons, cards, menus, and other components in one complete package if you're looking for that kind of stuff.
 
@@ -147,14 +147,14 @@ Dialog element backdrop can be clicked by the user to close the interface, its a
 
 ### Image
 
-| Props      | Default  |
-| ---------- | -------- |
-| src **\*** | `''`     |
-| alt *      | `''`     |
-| contain    | `false`  |
-| overlay    | `false`  |
-| absolute   | `false`  |
-| ratio      | `9 / 16` |
+| Props    | Default  |
+| -------- | -------- |
+| src *    | `''`     |
+| alt *    | `''`     |
+| contain  | `false`  |
+| overlay  | `false`  |
+| absolute | `false`  |
+| ratio    | `9 / 16` |
 
 Image element is created to have a fixed ratio, **not size**. It will be responsive by default and will follow its parent container size. To set a fixed size, just explicitly set the parent container size.
 
@@ -216,6 +216,49 @@ Image element is created to have a fixed ratio, **not size**. It will be respons
 
 <!-- Horizontal format -->
 <Image {src} {alt} ratio={3 / 4} />
+```
+
+### Pagination
+
+| Props     | Default       |
+| --------- | ------------- |
+| store *   | `writable(0)` |
+| total *   | `0`           |
+| bound     | `1`           |
+| increment | `bound`       |
+| tween     | `false`       |
+
+Pagination element handles all the complicated and unnecessary stuff for us, including all the edge cases. We just need to pass in the necessary props and handle the actual items slicing ourself.
+
+- `store` - a Svelte store to manage the state of the current paginated index.
+- `total` - usually just the `.length` of your data array
+- `bound` - maximum number of items per page
+- `increment` - number of items to skip every next/prev page
+- `tween` - boolean value to use tween increments rather than jump
+
+```svelte
+<script>
+  export let items = []; // Your data array
+  import { Pagination } from '@ignatiusmb/elements';
+  import { posts as store } from './stores.js';
+  const bound = 3;
+  const increment = 1;
+
+  $: count = $store * increment;
+  $: filtered = items.slice(count, count + bound);
+  $: total = filtered.length;
+</script>
+
+<Pagination {store} {total} {bound} {increment} tween />
+
+{#each filtered as post}
+  <div>
+    <h2>{post.title}</h2>
+    <p>{post.description}</p>
+  </div>
+{:else}
+  <h2>No posts available</h2>
+{/each}
 ```
 
 ***

--- a/README.md
+++ b/README.md
@@ -108,6 +108,114 @@ There's currently only one loader available to use, which is `ThreeWavyBalls`. M
 | `Observer` |                 | `WeavedImage`    |
 | `Overlay`  |                 |                  |
 
+### Dialog
+
+| Props | Default |
+| ----- | ------- |
+| show  | `false` |
+
+Dialog element backdrop can be clicked by the user to close the interface, its almost exactly the same as [`Modal`](#modal) with some minor difference in functionality, see [this question on Quora](https://www.quora.com/Whats-the-difference-between-a-modal-and-dialog) for more details on why.
+
+- `show` -
+
+```svelte
+<script>
+  import { Dialog } from '@ignatiusmb/elements';
+</script>
+
+<Dialog show>
+  <!-- Immediately shows the Dialog -->
+</Dialog>
+```
+
+```svelte
+<script>
+  import { Dialog } from '@ignatiusmb/elements';
+  let show = false;
+</script>
+
+<button on:click={() => (show = true)}>Show</button>
+
+<!-- Use "bind:" so "show" variable here will be updated too -->
+<Dialog bind:show>
+  <!-- Optional: Explicitly have button to close "Dialog" inside -->
+  <button on:click={() => (show = false)}>Close</button>
+</Dialog>
+```
+
+### Image
+
+| Props      | Default  |
+| ---------- | -------- |
+| src **\*** | `''`     |
+| alt *      | `''`     |
+| contain    | `false`  |
+| overlay    | `false`  |
+| absolute   | `false`  |
+| ratio      | `9 / 16` |
+
+Image element is created to have a fixed ratio, **not size**. It will be responsive by default and will follow its parent container size. To set a fixed size, just explicitly set the parent container size.
+
+- `contain` - images will have property `object-fit` with the value of `cover` by default, pass this prop to set the value to `contain`
+
+```svelte
+<script>
+  import { Image } from '@ignatiusmb/elements';
+  const src = "//example.com/image.png";
+  const alt = "An example text for this element";
+</script>
+
+<Image {src} {alt} contain />
+```
+
+- `overlay` - Overlay element is provided and available to use if you need it, you can pass in other components when this prop is used
+
+```svelte
+<script>
+  import { Image } from '@ignatiusmb/elements';
+  const src = "//example.com/image.png";
+  const alt = "An example text for this element";
+</script>
+
+<Image {src} {alt} overlay>
+  <p>I will appear when this Image is hovered</p>
+</Image>
+```
+
+- `absolute` - set the Image container position as absolute
+
+```svelte
+<script>
+  import { Image } from '@ignatiusmb/elements';
+  const src = "//example.com/image.png";
+  const alt = "An example text for this element";
+</script>
+
+<div style="position: relative">
+  <!-- Image is now absolute positioned in this div -->
+  <Image {src} {alt} absolute />
+</div>
+```
+
+- `ratio` - this receives a float to determine the ratio of your image, set to 16:9 by default
+
+```svelte
+<script>
+  import { Image } from '@ignatiusmb/elements';
+  const src = "//example.com/image.png";
+  const alt = "An example text for this element";
+</script>
+
+<!-- Square Image -->
+<Image {src} {alt} ratio={1} />
+
+<!-- Vertical format -->
+<Image {src} {alt} ratio={4 / 3} />
+
+<!-- Horizontal format -->
+<Image {src} {alt} ratio={3 / 4} />
+```
+
 ***
 
 <h3 align="center"><pre>

--- a/src/ButtonLink.svelte
+++ b/src/ButtonLink.svelte
@@ -29,7 +29,7 @@
 		padding: 0.5em 1em;
 		text-shadow: 0 2ch 0 var(--fg-surface, rgba(255, 255, 255, 0.65));
 		transform: translateY(-2ch);
-		transition: all var(--t-duration) ease-in-out;
+		transition: all var(--t-duration, 300ms) ease-in-out;
 	}
 	span:hover,
 	span:active {

--- a/src/Pagination.svelte
+++ b/src/Pagination.svelte
@@ -48,6 +48,8 @@
 	}
 	span {
 		cursor: pointer;
+		display: inline-flex;
+		justify-content: center;
 	}
 	span.disabled {
 		cursor: not-allowed;

--- a/src/Pagination.svelte
+++ b/src/Pagination.svelte
@@ -4,10 +4,19 @@
 	export let total = 0;
 	export let bound = 1;
 	export let increment = bound;
+	export let tween = false;
 	import { ChevronsLeft, ChevronLeft, ChevronsRight, ChevronRight } from './icons';
 	function update(index) {
 		if (index < 0 || index > limit) return;
-		$store = index;
+		if (tween && (index === 0 || index === limit)) {
+			let timeout = null;
+			const repeat = () => {
+				$store = index === 0 ? $store - 1 : $store + 1;
+				if ($store === 0 || $store === limit) clearTimeout(timeout);
+				else timeout = setTimeout(repeat, 50);
+			};
+			timeout = setTimeout(repeat, 50);
+		} else $store = index;
 	}
 	$: ceil = Math.ceil((total - bound) / increment);
 	$: limit = ceil < 0 ? 0 : ceil;

--- a/src/Pagination.svelte
+++ b/src/Pagination.svelte
@@ -12,7 +12,7 @@
 	$: ceil = Math.ceil((total - bound) / increment);
 	$: limit = ceil < 0 ? 0 : ceil;
 
-	$: curr = $store * increment + 1;
+	$: curr = total ? $store * increment + 1 : 0;
 	$: comp = curr - 1 + bound;
 	$: next = comp <= total ? comp : total;
 </script>

--- a/src/Pagination.svelte
+++ b/src/Pagination.svelte
@@ -11,6 +11,7 @@
 	}
 	$: ceil = Math.ceil((total - bound) / increment);
 	$: limit = ceil < 0 ? 0 : ceil;
+	$: $store = $store > limit ? limit : $store;
 
 	$: curr = total ? $store * increment + 1 : 0;
 	$: comp = curr - 1 + bound;

--- a/src/Pagination.svelte
+++ b/src/Pagination.svelte
@@ -9,10 +9,12 @@
 		if (index < 0 || index > limit) return;
 		$store = index;
 	}
+	$: ceil = Math.ceil((total - bound) / increment);
+	$: limit = ceil < 0 ? 0 : ceil;
+
 	$: curr = $store * increment + 1;
 	$: comp = curr - 1 + bound;
 	$: next = comp <= total ? comp : total;
-	$: limit = Math.ceil((total - bound) / increment);
 </script>
 
 <section class="lmns lmns-pagination">

--- a/src/Pagination.svelte
+++ b/src/Pagination.svelte
@@ -3,18 +3,16 @@
 	export let store = writable(0);
 	export let total = 0;
 	export let bound = 1;
+	export let increment = bound;
 	import { ChevronsLeft, ChevronLeft, ChevronsRight, ChevronRight } from './icons';
 	function update(index) {
-		if (index < 0) return;
-		index = Math.round(index);
-		if (index < $store) $store = index;
-		else if (comp > total) return;
+		if (index < 0 || index > limit) return;
 		$store = index;
 	}
-	$: curr = $store * bound + 1;
+	$: curr = $store * increment + 1;
 	$: comp = curr - 1 + bound;
 	$: next = comp <= total ? comp : total;
-	$: limit = Math.floor(total / bound);
+	$: limit = Math.ceil((total - bound) / increment);
 </script>
 
 <section class="lmns lmns-pagination">


### PR DESCRIPTION
- Add new exported prop `increment` to specify items per update
- Fix `limit` going negative value and right Chevrons disabled class gets removed
- Fix `total` value 0 but `curr` is still incremented by one
- Fix `total` value changed but `$store` isn't readjusted